### PR TITLE
protect options from replay attack (stable branch)

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1341,7 +1341,7 @@ handle_null_request(int tun_fd, int dns_fd, struct dnsfd *dns_fds, struct query 
 
 		userid = b32_8to5(in[1]);
 
-		if (check_authenticated_user_and_ip(userid, q) != 0) {
+		if (check_authenticated_user_and_ip_and_options(userid, q) != 0) {
 			write_dns(dns_fd, q, "BADIP", 5, 'T');
 			return; /* illegal id */
 		}
@@ -1387,7 +1387,7 @@ handle_null_request(int tun_fd, int dns_fd, struct dnsfd *dns_fds, struct query 
 
 		userid = b32_8to5(in[1]);
 
-		if (check_authenticated_user_and_ip(userid, q) != 0) {
+		if (check_authenticated_user_and_ip_and_options(userid, q) != 0) {
 			write_dns(dns_fd, q, "BADIP", 5, 'T');
 			return; /* illegal id */
 		}
@@ -1563,7 +1563,7 @@ handle_null_request(int tun_fd, int dns_fd, struct dnsfd *dns_fds, struct query 
 
 		/* Downstream fragsize packet */
 		userid = unpacked[0];
-		if (check_authenticated_user_and_ip(userid, q) != 0) {
+		if (check_authenticated_user_and_ip_and_options(userid, q) != 0) {
 			write_dns(dns_fd, q, "BADIP", 5, 'T');
 			return; /* illegal id */
 		}
@@ -1573,6 +1573,7 @@ handle_null_request(int tun_fd, int dns_fd, struct dnsfd *dns_fds, struct query 
 			write_dns(dns_fd, q, "BADFRAG", 7, users[userid].downenc);
 		} else {
 			users[userid].fragsize = max_frag_size;
+			users[userid].options_locked = 1;
 			users[userid].outgoing->maxfraglen = (users[userid].downenc_bits * max_frag_size) /
 				8 - DOWNSTREAM_PING_HDR;
 			write_dns(dns_fd, q, (char *) unpacked + 1, 2, users[userid].downenc);

--- a/src/user.c
+++ b/src/user.c
@@ -159,6 +159,7 @@ find_available_user()
 			user->active = 1;
 			user->authenticated = 0;
 			user->authenticated_raw = 0;
+			user->options_locked = 0;
 			user->last_pkt = time(NULL);
 			user->fragsize = MAX_FRAGSIZE;
 			user->conn = CONN_DNS_NULL;
@@ -238,6 +239,19 @@ check_authenticated_user_and_ip(int userid, struct query *q)
 		return res;
 
 	if (!users[userid].authenticated)
+		return 1;
+
+	return 0;
+}
+
+int
+check_authenticated_user_and_ip_and_options(int userid, struct query *q)
+{
+	int res = check_authenticated_user_and_ip(userid, q);
+	if (res || check_ip)
+		return res;
+
+	if (users[userid].options_locked)
 		return 1;
 
 	return 0;

--- a/src/user.h
+++ b/src/user.h
@@ -29,6 +29,7 @@ struct tun_user {
 	int active;
 	int authenticated;
 	int authenticated_raw;
+	int options_locked;
 	time_t last_pkt;
 	struct timeval dns_timeout;
 	int seed;
@@ -55,6 +56,7 @@ int user_sending(int user);
 int all_users_waiting_to_send();
 int user_active(int i);
 int check_authenticated_user_and_ip(int userid, struct query *q);
+int check_authenticated_user_and_ip_and_options(int userid, struct query *q);
 int check_user_and_ip(int userid, struct query *q);
 
 int init_users(in_addr_t, int);


### PR DESCRIPTION
Trying to determine why long-running sessions inexplicably become slow, I ran tcpdump and found unsolicited DNS queries beginning with the letter N were severely reducing the downstream fragment size.

When using carrier-grade DNS, the server is especially vulnerable to replay attacks that abuse the options commands (DNS queries beginning with N or O or S). I suggest refusing options commands after the negotiation of options has completed.
