### PR TITLE
protect options from replay attack

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1566,6 +1566,11 @@ handle_dns_upstream_codec_switch(int dns_fd, struct query *q, int userid,
 	int codec;
 	struct encoder *enc;
 
+	if (!server.check_ip && users[userid].options_locked) {
+		write_dns(dns_fd, q, "BADIP", 5, 'T');
+		return;
+	}
+
 	codec = unpacked[0];
 
 	switch (codec) {
@@ -1603,6 +1608,11 @@ handle_dns_set_options(int dns_fd, struct query *q, int userid,
 	char *encname = "BADCODEC";
 
 	int tmp_lazy, tmp_downenc, tmp_comp;
+
+	if (!server.check_ip && users[userid].options_locked) {
+		write_dns(dns_fd, q, "BADIP", 5, 'T');
+		return;
+	}
 
 	/* Temporary variables: don't change anything until all options parsed */
 	tmp_lazy = users[userid].lazy;
@@ -1700,12 +1710,19 @@ handle_dns_set_fragsize(int dns_fd, struct query *q, int userid,
 	/* Downstream fragsize packet */
 {
 	int max_frag_size;
+
+	if (!server.check_ip && users[userid].options_locked) {
+		write_dns(dns_fd, q, "BADIP", 5, 'T');
+		return;
+	}
+
 	max_frag_size = ntohs(*(uint16_t *)unpacked);
 
 	if (max_frag_size < 2 || max_frag_size > MAX_FRAGSIZE) {
 		write_dns(dns_fd, q, "BADFRAG", 7, users[userid].downenc);
 	} else {
 		users[userid].fragsize = max_frag_size;
+		users[userid].options_locked = 1;
 		users[userid].outgoing->maxfraglen = (users[userid].downenc_bits * max_frag_size) /
 			8 - DOWNSTREAM_PING_HDR;
 		write_dns(dns_fd, q, (char *)unpacked, 2, users[userid].downenc);

--- a/src/user.c
+++ b/src/user.c
@@ -153,6 +153,7 @@ find_available_user()
 			user->active = 1;
 			user->authenticated = 0;
 			user->authenticated_raw = 0;
+			user->options_locked = 0;
 			user->last_pkt = time(NULL);
 			user->fragsize = MAX_FRAGSIZE;
 			user->conn = CONN_DNS_NULL;

--- a/src/user.h
+++ b/src/user.h
@@ -29,6 +29,7 @@ struct tun_user {
 	int active;
 	int authenticated;
 	int authenticated_raw;
+	int options_locked;
 	time_t last_pkt;
 	struct timeval dns_timeout;
 	int seed;


### PR DESCRIPTION
Trying to determine why long-running sessions inexplicably become slow, I ran tcpdump and found unsolicited DNS queries beginning with the letter N were severely reducing the downstream fragment size.

When using carrier-grade DNS, the server is especially vulnerable to replay attacks that abuse the options commands (DNS queries beginning with N or O or S). I suggest refusing options commands after the negotiation of options has completed.
