### PR TITLE
Store the length of name servers addresses

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -352,8 +352,8 @@ send_query(uint8_t *hostname)
 
 	DEBUG(4, "  Sendquery: id %5d name[0] '%c'", q.id, hostname[0]);
 
-	sendto(this.dns_fd, packet, len, 0, (struct sockaddr*) &this.nameserv_addrs[this.current_nameserver],
-			sizeof(struct sockaddr_storage));
+	sendto(this.dns_fd, packet, len, 0, (struct sockaddr*) &this.nameserv_addrs[this.current_nameserver].addr,
+			this.nameserv_addrs[this.current_nameserver].len);
 
 	client_rotate_nameserver();
 

--- a/src/client.c
+++ b/src/client.c
@@ -135,7 +135,7 @@ void
 client_rotate_nameserver()
 {
 	this.current_nameserver ++;
-	if (this.current_nameserver >= this.nameserv_addrs_len)
+	if (this.current_nameserver >= this.nameserv_addrs_count)
 		this.current_nameserver = 0;
 }
 

--- a/src/client.h
+++ b/src/client.h
@@ -38,7 +38,7 @@ struct client_instance {
 	char **nameserv_hosts;
 	size_t nameserv_hosts_len;
 	struct sockaddr_storage *nameserv_addrs;
-	size_t nameserv_addrs_len;
+	size_t nameserv_addrs_count;
 	int current_nameserver;
 	struct sockaddr_storage raw_serv;
 	int raw_serv_len;

--- a/src/client.h
+++ b/src/client.h
@@ -26,6 +26,11 @@ extern int stats;
 #define PENDING_QUERIES_LENGTH (MAX(this.windowsize_up, this.windowsize_down) * 4)
 #define INSTANCE this
 
+struct nameserv {
+	struct sockaddr_storage addr;
+	int len;
+};
+
 struct client_instance {
 	int max_downstream_frag_size;
 	int autodetect_frag_size;
@@ -37,7 +42,7 @@ struct client_instance {
 	/* DNS nameserver info */
 	char **nameserv_hosts;
 	size_t nameserv_hosts_len;
-	struct sockaddr_storage *nameserv_addrs;
+	struct nameserv *nameserv_addrs;
 	size_t nameserv_addrs_count;
 	int current_nameserver;
 	struct sockaddr_storage raw_serv;

--- a/src/iodine.c
+++ b/src/iodine.c
@@ -645,11 +645,11 @@ main(int argc, char **argv)
 					nameserv_host, gai_strerror(nameservaddr_len));
 		}
 		memcpy(&this.nameserv_addrs[n], &nameservaddr, sizeof(struct sockaddr_storage));
-		this.nameserv_addrs_len ++;
+		this.nameserv_addrs_count ++;
 		nameserv_host = NULL;
 	}
 
-	if (this.nameserv_addrs_len <= 0 || !this.nameserv_hosts[0]) {
+	if (this.nameserv_addrs_count <= 0 || !this.nameserv_hosts[0]) {
 		warnx("No nameservers found - not connected to any network?");
 		usage();
 	}
@@ -732,9 +732,9 @@ main(int argc, char **argv)
 	signal(SIGTERM, sighandler);
 
 	fprintf(stderr, "Sending DNS queries for %s to ", this.topdomain);
-	for (int a = 0; a < this.nameserv_addrs_len; a++)
+	for (int a = 0; a < this.nameserv_addrs_count; a++)
 		fprintf(stderr, "%s%s", format_addr(&this.nameserv_addrs[a], sizeof(struct sockaddr_storage)),
-				(a != this.nameserv_addrs_len - 1) ?  ", " : "");
+				(a != this.nameserv_addrs_count - 1) ?  ", " : "");
 	fprintf(stderr, "\n");
 
 	if (this.remote_forward_addr.ss_family != AF_UNSPEC)

--- a/src/iodine.c
+++ b/src/iodine.c
@@ -622,7 +622,7 @@ main(int argc, char **argv)
 
 	// Preallocate memory with expected number of hosts
 	this.nameserv_hosts = malloc(sizeof(char *) * this.nameserv_hosts_len);
-	this.nameserv_addrs = malloc(sizeof(struct sockaddr_storage) * this.nameserv_hosts_len);
+	this.nameserv_addrs = malloc(sizeof(struct nameserv) * this.nameserv_hosts_len);
 
 	if (argc == 0) {
 		usage();
@@ -644,7 +644,8 @@ main(int argc, char **argv)
 			errx(1, "Cannot lookup nameserver '%s': %s ",
 					nameserv_host, gai_strerror(nameservaddr_len));
 		}
-		memcpy(&this.nameserv_addrs[n], &nameservaddr, sizeof(struct sockaddr_storage));
+		this.nameserv_addrs[n].len = nameservaddr_len;
+		memcpy(&this.nameserv_addrs[n].addr, &nameservaddr, sizeof(struct sockaddr_storage));
 		this.nameserv_addrs_count ++;
 		nameserv_host = NULL;
 	}
@@ -733,7 +734,7 @@ main(int argc, char **argv)
 
 	fprintf(stderr, "Sending DNS queries for %s to ", this.topdomain);
 	for (int a = 0; a < this.nameserv_addrs_count; a++)
-		fprintf(stderr, "%s%s", format_addr(&this.nameserv_addrs[a], sizeof(struct sockaddr_storage)),
+		fprintf(stderr, "%s%s", format_addr(&this.nameserv_addrs[a].addr, this.nameserv_addrs[a].len),
 				(a != this.nameserv_addrs_count - 1) ?  ", " : "");
 	fprintf(stderr, "\n");
 


### PR DESCRIPTION
iodine was broken on macOS and BSD since 3e7cf55fe4ef091b3b492f31e83fab5d0637860a due to this.
The correct size has to be given to `sento()` on these systems.