### PR TITLE
add fine-tuning option -J to set delay variance factor

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -322,7 +322,7 @@ got_response(int id, int immediate, int fail)
 				this.rtt_total_ms += rtt_ms;
 				this.num_immediate++;
 
-				if (this.autodetect_server_timeout && this.lazymode)
+				if (this.autodetect_server_timeout)
 					update_server_timeout(0);
 			}
 

--- a/src/client.c
+++ b/src/client.c
@@ -209,7 +209,7 @@ update_server_timeout(int handshake)
 	}
 
 	/* update up/down window timeouts to something reasonable */
-	this.downstream_timeout_ms = rtt_ms * 2;
+	this.downstream_timeout_ms = rtt_ms * this.downstream_delay_variance / 100;
 	this.outbuf->timeout = ms_to_timeval(this.downstream_timeout_ms);
 
 	if (handshake) {

--- a/src/client.c
+++ b/src/client.c
@@ -209,7 +209,7 @@ update_server_timeout(int handshake)
 	}
 
 	/* update up/down window timeouts to something reasonable */
-	this.downstream_timeout_ms = rtt_ms * this.downstream_delay_variance / 100;
+	this.downstream_timeout_ms = rtt_ms * this.downstream_delay_variance;
 	this.outbuf->timeout = ms_to_timeval(this.downstream_timeout_ms);
 
 	if (handshake) {

--- a/src/client.h
+++ b/src/client.h
@@ -90,6 +90,7 @@ struct client_instance {
 	time_t downstream_timeout_ms;
 	double downstream_delay_variance;
 	int autodetect_server_timeout;
+	int autodetect_delay_variance;
 
 	/* Cumulative Round-Trip-Time in ms */
 	time_t rtt_total_ms;

--- a/src/client.h
+++ b/src/client.h
@@ -88,7 +88,7 @@ struct client_instance {
 	/* Server response timeout in ms and downstream window timeout */
 	time_t server_timeout_ms;
 	time_t downstream_timeout_ms;
-	time_t downstream_delay_variance;
+	double downstream_delay_variance;
 	int autodetect_server_timeout;
 
 	/* Cumulative Round-Trip-Time in ms */

--- a/src/client.h
+++ b/src/client.h
@@ -88,6 +88,7 @@ struct client_instance {
 	/* Server response timeout in ms and downstream window timeout */
 	time_t server_timeout_ms;
 	time_t downstream_timeout_ms;
+	time_t downstream_delay_variance;
 	int autodetect_server_timeout;
 
 	/* Cumulative Round-Trip-Time in ms */

--- a/src/iodine.c
+++ b/src/iodine.c
@@ -82,7 +82,7 @@ struct client_instance this;
 	.next_downstream_ack = -1, \
 	.num_immediate = 1, \
 	.rtt_total_ms = 200, \
-	.downstream_delay_variance = 200, \
+	.downstream_delay_variance = 2.0, \
 	.remote_forward_addr = {.ss_family = AF_UNSPEC}
 
 static struct client_instance preset_default = {
@@ -576,7 +576,7 @@ main(int argc, char **argv)
 			}
 			break;
 		case 'J':
-			this.downstream_delay_variance = strtod(optarg, NULL) * 100;
+			this.downstream_delay_variance = strtod(optarg, NULL);
 			break;
 		case 's':
 			this.send_interval_ms = atoi(optarg);
@@ -696,7 +696,7 @@ main(int argc, char **argv)
 		usage();
 	}
 
-	if (this.downstream_delay_variance < 10) {
+	if (this.downstream_delay_variance < 0.1) {
 		warnx("Delay variance factor must be more than 0.1 to prevent excessive retransmits.");
 		usage();
 	}

--- a/src/iodine.c
+++ b/src/iodine.c
@@ -83,6 +83,7 @@ struct client_instance this;
 	.num_immediate = 1, \
 	.rtt_total_ms = 200, \
 	.downstream_delay_variance = 2.0, \
+	.autodetect_delay_variance = 0, \
 	.remote_forward_addr = {.ss_family = AF_UNSPEC}
 
 static struct client_instance preset_default = {
@@ -265,7 +266,7 @@ help()
 	fprintf(stderr, "  -W  upstream fragment window size (default: 8 frags)\n");
 	fprintf(stderr, "  -i  server-side request timeout in lazy mode (default: auto)\n");
 	fprintf(stderr, "  -j  downstream fragment ACK timeout, implies -i4 (default: 2 sec)\n");
-	fprintf(stderr, "  -J  downstream fragment ACK delay variance factor (default: 2.0)\n");
+	fprintf(stderr, "  -J  downstream fragment ACK delay variance factor (default: 2.0), 0: auto\n");
 	//fprintf(stderr, "  --nodrop  disable TCP packet-dropping optimisations\n");
 	fprintf(stderr, "  -c 1: use downstream compression (default), 0: disable\n");
 	fprintf(stderr, "  -C 1: use upstream compression (default), 0: disable\n\n");
@@ -577,6 +578,10 @@ main(int argc, char **argv)
 			break;
 		case 'J':
 			this.downstream_delay_variance = strtod(optarg, NULL);
+			if (0.0 == this.downstream_delay_variance) {
+				this.autodetect_delay_variance = 1;
+				this.downstream_delay_variance = 2.0;
+			}
 			break;
 		case 's':
 			this.send_interval_ms = atoi(optarg);


### PR DESCRIPTION
For the situation where round-trip time fluctuates within a known variance, allow the user to specify the variance factor used to calculate the downstream fragment ACK timeout.