### PR TITLE
window size zero (-W0) drops packets from client tun device

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -1015,7 +1015,7 @@ tunnel_tun()
 
 	if (this.conn == CONN_DNS_NULL) {
 		/* Check if outgoing buffer can hold data */
-		if (window_buffer_available(this.outbuf) < (read / MAX_FRAGSIZE) + 1) {
+		if ((0 == this.windowsize_up && 0 != this.outbuf->numitems) || window_buffer_available(this.outbuf) < (read / MAX_FRAGSIZE) + 1) {
 			DEBUG(1, "  Outgoing buffer full (%" L "u/%" L "u), not adding data!",
 						this.outbuf->numitems, this.outbuf->length);
 			return -1;
@@ -1340,7 +1340,7 @@ client_tunnel()
 
 		FD_ZERO(&fds);
 		maxfd = 0;
-		if (this.conn != CONN_DNS_NULL || window_buffer_available(this.outbuf) > 1) {
+		if (this.conn != CONN_DNS_NULL || 0 == this.windowsize_up || window_buffer_available(this.outbuf) > 1) {
 			/* Fill up outgoing buffer with available data if it has enough space
 			 * The windowing protocol manages data retransmits, timeouts etc. */
 			if (this.use_remote_forward) {
@@ -2702,7 +2702,7 @@ client_handshake()
 			return -1;
 
 		/* init windowing protocol */
-		this.outbuf = window_buffer_init(64, this.windowsize_up, this.maxfragsize_up, WINDOW_SENDING);
+		this.outbuf = window_buffer_init(64, (0 == this.windowsize_up ? 1 : this.windowsize_up), this.maxfragsize_up, WINDOW_SENDING);
 		this.outbuf->timeout = ms_to_timeval(this.downstream_timeout_ms);
 		/* Incoming buffer max fragsize doesn't matter */
 		this.inbuf = window_buffer_init(64, this.windowsize_down, MAX_FRAGSIZE, WINDOW_RECVING);

--- a/src/iodine.c
+++ b/src/iodine.c
@@ -669,7 +669,7 @@ main(int argc, char **argv)
 	}
 
 	int max_ws = MAX_SEQ_ID / 2;
-	if (this.windowsize_up < 1 || this.windowsize_down < 1 ||
+	if (this.windowsize_up < 0 || this.windowsize_down < 1 ||
 		this.windowsize_up > max_ws || this.windowsize_down > max_ws) {
 		warnx("Window sizes (-w or -W) must be between 0 and %d!", max_ws);
 		usage();


### PR DESCRIPTION
Although not of great benefit to the sliding window protocol, perhaps dropping whole packets from the client tun device could be a useful option to have anyway.

Keeping the upstream window free of congestion by dropping packets instead of queuing packets results in a speed boost which correlates with the packet delay variation.  Especially if delay variation exists because of bufferbloat on the underlying network, dropping packets eliminates the symptoms of bufferbloat since packets are not buffered.  The upstream window receives at most one packet worth of fragments, and new packets are not delayed in the tun device buffer or in the upstream window.  However concurrent flows become problematic as one flow becomes dominant and other flows see massive packet loss.

The same throughput is seen by `-W0` as is seen by an upstream window size approximately equal to the delay variance factor, generally `-W2` depending on network conditions.  The difference is reduced capacity for concurrency as chance of entry into the window becomes a bottleneck.

Protocol 502 supports only the equivalent of the `-W1` option and so to take advantage of packet delay variation to reach the equivalent of `-W2` is a significant improvement.  Also with only one fragment in flight, the protocol naturally has limited capacity for concurrency.

Protocol 800 supports `-W2` without resorting to packet loss to achieve it, and windowing naturally allows for concurrency.  Yet when concurrency is not required, `-W0` could be advantageous to boost the speed of a single flow under favorable network conditions.

Delay variation influences throughput more than I realized, since I have had the opportunity to tune the `-J` option to match the variation factor on multiple different networks. I have used ping to measure `(avg/min)` ratios ranging from 1.0 to 3.0, and in each case tuning `-J` to match has improved reliability by smoothing the transfer rate toward an average.

