### PR TITLE
improve -J0 auto calculation of delay variance factor

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -328,8 +328,8 @@ got_response(int id, int immediate, int fail)
 						if (rtt_ms > 0 && (rtt_ms < rtt_min_ms || 1 == rtt_min_ms)) {
 							rtt_min_ms = rtt_ms;
 						}
-						this.downstream_delay_variance = (double) (this.rtt_total_ms /
-							this.num_immediate) / rtt_min_ms;
+						this.downstream_delay_variance = 2.0 - (double) rtt_min_ms /
+							(double) (this.rtt_total_ms / this.num_immediate);
 					}
 					update_server_timeout(0);
 				}


### PR DESCRIPTION
The option -J0 measures the minimum RTT to determine the delay variance factor automatically.

The formula of (avg/min) is a simplistic lopsided estimate of the factor which adequately compensates for delay but which inadequately compensates for loss.

Assuming symmetric variance around the average, maximum can be predicted from the observed minimum, and factor can be calculated from the predicted maximum.

variance = average-minimum
maximum = average+variance
factor = maximum/average

= (avg+(avg-min))/avg
= ((avg+avg)-min)/avg
= (avg+avg)/avg - (min/avg)
= 2*avg/avg - (min/avg)
= 2-(min/avg)

Thus 2-(min/avg) is a better estimate.